### PR TITLE
Public Sans - Bugfix: Remove old gtag

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -7,8 +7,9 @@
 <!-- ================================= -->
 
 <head>
-  <!-- GA4 -->
-  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id=G-HBYXWFP794"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-HBYXWFP794'); </script>
+  <!-- GA4 - Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-HBYXWFP794"></script>
+  <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-HBYXWFP794'); </script>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -12,17 +12,7 @@
     {{ content }}
   </main>
   {% include footer.html %}
+
   <script src="{{ "/assets/uswds/js/uswds.min.js" | relative_url }}"></script>
-
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-47271808-2"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-47271808-2');
-  </script>
-
 </body>
 </html>


### PR DESCRIPTION
This PR removes old and duplicate Google Analytics code. Closes #337.

> [!NOTE]
> After this is merged we'll have to merge `develop` into `site` to see this live.


## Preview

Confirm all pages have the new GA4 code.

[Preview →](https://federalist-514d1714-e827-44f8-a29f-3ec1837bf619.sites.pages.cloud.gov/preview/uswds/public-sans/jm-ga4-debugging-337/)


## How to test

The GA tracking code should be available in the `<head>` of all pages.