### PR TITLE
Public Sans Site: update GA ID

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -8,7 +8,7 @@
 
 <head>
   <!-- GA4 -->
-  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id="G-S15458JF4T"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-S15458JF4T'); </script>
+  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id=G-S15458JF4T"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-S15458JF4T'); </script>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -8,7 +8,7 @@
 
 <head>
   <!-- GA4 -->
-  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id=G-HBYXWFP794"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-HBYXWFP794'); </script>
+  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id="></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-S15458JF4T'); </script>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -8,7 +8,7 @@
 
 <head>
   <!-- GA4 -->
-  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id="></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-S15458JF4T'); </script>
+  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id="G-S15458JF4T"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-S15458JF4T'); </script>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Update GA rollup ID

[Preview link](https://federalist-514d1714-e827-44f8-a29f-3ec1837bf619.sites.pages.cloud.gov/preview/uswds/public-sans/mh-update-ga-id/)