### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/uswds/public-sans)
+
 :exclamation: **Site retiring** :exclamation:
 
 As of February 2026, the team (currently solely Anne Petersen) plans to retire the [Public Sans website](https://public-sans.digital.gov/). 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/uswds/public-sans) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.