### PR TITLE
[Public Sans readme] site retiring update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 :exclamation: **Site retiring** :exclamation:
 
-As of February 2026, the team (currently solely Anne Petersen) plans to retire the [Public Sans website](https://public-sans.digital.gov/). 
+As of February 2026, the team (currently solely @annepetersen) plans to retire the live [Public Sans website](https://public-sans.digital.gov/), though the URL will resolve to [Digital.gov](https://digital.gov/)'s [Introduction to Typography page](https://digital.gov/resources/an-introduction-to-typography), hopefully in May 2026. [The Open Source Program Office of the Centers for Medicare and Medicaid Services](https://dsacms.github.io/ospo-guide/) has kindly volunteered to create a mirror in its absence.
 
-This repo still contains the source font files, currently **[Public Sans v2.001](https://designsystem.digital.gov/)**, but the font is not being actively developed or maintained. For more information about the site decommissioning, see the [relevant GitHub issue](https://github.com/uswds/public-sans/issues/363).
+This repo still contains the source font files, currently **[Public Sans v2.001]([https://designsystem.digital.gov/](https://designsystem.digital.gov/components/typography/#public-sans))**, but this font is not being actively developed or maintained. For more information about the site decommissioning, see the [relevant GitHub issue](https://github.com/uswds/public-sans/issues/363).
 
 # Public Sans
 


### PR DESCRIPTION
# Summary

- add intended date of site retirement 
- provide site redirect intent and URL
- note OSPO's intended mirror
- correct / clarify staffing

## Breaking change

This is not a breaking change.

## Related issue

Supports #363 

## Solution

So the community knows what to expect and when for the Public Sans site.