### PR TITLE
Update build-deploy.yml

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
@@ -41,12 +41,12 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # pin v6.0.0
         with:
-          node-version: '19.x'
+          node-version: '24.x'
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # pin v6.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
@@ -57,7 +57,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #pin v5.0.0
 
   # Deployment job
   deploy:
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 #pin v5.0.0


### PR DESCRIPTION
## Problem

Although #380 was merged, the mirror site (live at: https://uswds.github.io/public-sans/) is displaying the README of the public-sans repository, not the actual website build. This is due to the workflow to build and deploy the mirror site failing: https://github.com/uswds/public-sans/actions/runs/24912472584/job/72957098846. The repository has a security requirement where all GitHub actions must be pinned to a full-length commit SHA.

## Solution
This PR pins all GitHub Actions to full-length commit SHA, fulfilling the repository workflow requirements. 

## Result
Once this PR is merged, the website should be live at: https://uswds.github.io/public-sans/

## Test
The CMS OSPO performed testing in our own fork: https://github.com/DSACMS/public-sans
The build deploy workflow runs successfully with the website live at: https://dsacms.github.io/public-sans/